### PR TITLE
Icon for fasthub and fasthub-libre

### DIFF
--- a/other/fasthub.svg
+++ b/other/fasthub.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="fasthub.svg.2018_05_18_08_24_35.0.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1037"
+     id="namedview6"
+     showgrid="true"
+     inkscape:pagecheckerboard="true"
+     inkscape:snap-bbox="false"
+     inkscape:snap-bbox-edge-midpoints="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:bbox-paths="false"
+     inkscape:measure-start="24,13.7112"
+     inkscape:measure-end="25,14.3079"
+     inkscape:snap-object-midpoints="true"
+     inkscape:object-paths="false"
+     inkscape:bbox-nodes="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:zoom="16.000001"
+     inkscape:cx="30.626201"
+     inkscape:cy="23.814125"
+     inkscape:window-x="1920"
+     inkscape:window-y="43"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     inkscape:snap-grids="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid817"
+       empspacing="4"
+       snapvisiblegridlinesonly="false" />
+  </sodipodi:namedview>
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     d="M 24 2 A 22 22 0 0 0 2 24 A 22 22 0 0 0 24 46 A 22 22 0 0 0 46 24 A 22 22 0 0 0 24 2 z M 24 6 A 18 18 0 0 1 42 24 A 18 18 0 0 1 24 42 A 18 18 0 0 1 6 24 A 18 18 0 0 1 24 6 z "
+     id="circle2" />
+  <path
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3.88917994;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3687783;paint-order:normal"
+     d="M 17.230469 10.460938 A 0.76999998 0.76999998 0 0 0 16.460938 11.230469 A 0.76999998 0.76999998 0 0 0 16.6875 11.773438 L 16.685547 11.775391 L 18.669922 13.759766 A 9 9 0 0 0 15 21 L 15 22.449219 A 1.8 1.8 0 0 1 13.199219 24.25 A 1.8 1.8 0 0 1 11.400391 22.449219 A 1.3750001 1.3750001 0 0 0 10.025391 21.074219 A 1.3750001 1.3750001 0 0 0 8.6503906 22.449219 A 1.3750001 1.3750001 0 0 0 8.65625 22.564453 A 4.5500002 4.5500002 0 0 0 13.199219 27 A 4.5500002 4.5500002 0 0 0 15 26.626953 L 15 30.453125 L 15 31.916016 L 15 34.234375 A 1.5 1.4180363 0 0 0 16.5 35.652344 A 1.5 1.4180363 0 0 0 18 34.234375 L 18 31.916016 L 18.001953 31.916016 A 1 0.94535752 0 0 1 18 31.871094 A 1 0.94535752 0 0 1 19 30.925781 A 1 0.94535752 0 0 1 20 31.871094 A 1 0.94535752 0 0 1 19.998047 31.916016 L 20 31.916016 L 20 37.070312 L 20.015625 37.070312 A 1.5 1.4180363 0 0 0 21.5 38.300781 A 1.5 1.4180363 0 0 0 22.984375 37.070312 L 23 37.070312 L 23 31.916016 L 23.001953 31.916016 A 1 0.94535752 0 0 1 23 31.871094 A 1 0.94535752 0 0 1 24 30.925781 A 1 0.94535752 0 0 1 25 31.871094 A 1 0.94535752 0 0 1 24.998047 31.916016 L 25 31.916016 L 25 37.070312 L 25.015625 37.070312 A 1.5 1.4180363 0 0 0 26.5 38.300781 A 1.5 1.4180363 0 0 0 27.984375 37.070312 L 28 37.070312 L 28 31.916016 L 28.001953 31.916016 A 1 0.94535752 0 0 1 28 31.871094 A 1 0.94535752 0 0 1 29 30.925781 A 1 0.94535752 0 0 1 30 31.871094 A 1 0.94535752 0 0 1 29.998047 31.916016 L 30 31.916016 L 30 34.234375 A 1.5 1.4180363 0 0 0 31.5 35.652344 A 1.5 1.4180363 0 0 0 33 34.234375 L 33 31.916016 L 33 30.453125 L 33 21 A 9 9 0 0 0 29.330078 13.759766 L 31.314453 11.775391 L 31.3125 11.773438 A 0.76999998 0.76999998 0 0 0 31.539062 11.230469 A 0.76999998 0.76999998 0 0 0 30.769531 10.460938 A 0.76999998 0.76999998 0 0 0 30.224609 10.685547 A 0.76999998 0.76999998 0 0 0 30.216797 10.693359 L 27.972656 12.9375 A 9 9 0 0 0 24 12 A 9 9 0 0 0 20.021484 12.931641 L 17.783203 10.693359 A 0.76999998 0.76999998 0 0 0 17.775391 10.685547 A 0.76999998 0.76999998 0 0 0 17.230469 10.460938 z M 20.675781 17.945312 C 21.747535 17.98848 22.889923 18.144531 24 18.144531 C 25.110077 18.144531 26.223907 17.986162 27.324219 17.945312 C 28.979933 17.883851 30.324219 19.288459 30.324219 20.945312 C 30.324219 22.602167 28.730885 23.799398 27.324219 23.945312 C 26.217556 24.060123 25.100883 24.056773 23.988281 24.056641 C 22.883488 24.056511 21.774444 24.061533 20.675781 23.945312 C 19.269414 23.79654 17.675781 22.602166 17.675781 20.945312 C 17.675781 19.288458 19.020269 17.878632 20.675781 17.945312 z "
+     id="path830-7" />
+  <ellipse
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3687783;paint-order:normal"
+     id="path1114"
+     cx="20.299999"
+     cy="21"
+     ry="1.6"
+     rx="1.3" />
+  <ellipse
+     style="opacity:1;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3687783;paint-order:normal"
+     id="path1114-0"
+     cx="27.700001"
+     cy="21"
+     ry="1.6"
+     rx="1.3" />
+</svg>


### PR DESCRIPTION
Fasthub-libre: com.fastaccess.github.libre/com.fastaccess.ui.modules.main.MainActivity

Yalp won't work so i can't download the fasthub app to get the activity strings for it, but it has the same icon.