### PR TITLE
Fixes discord logo app

### DIFF
--- a/other/discord.svg
+++ b/other/discord.svg
@@ -1,66 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="Layer_1"
-   viewBox="0 0 50 50"
-   version="1.1"
-   sodipodi:docname="discord.svg"
-   width="50"
-   height="50"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14">
-  <metadata
-     id="metadata13">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <defs
-     id="defs11" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1276"
-     inkscape:window-height="716"
-     id="namedview9"
-     showgrid="false"
-     inkscape:pagecheckerboard="true"
-     inkscape:zoom="6.4111015"
-     inkscape:cx="14.250061"
-     inkscape:cy="16.725008"
-     inkscape:window-x="2"
-     inkscape:window-y="2"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Layer_1" />
-  <style
-     id="style2">.st0{fill:#FFFFFF;}</style>
+   width="48"
+   height="48"
+  >
   <path
-     class="st0"
      d="m 20.781548,20.975 c -1.425,0 -2.55,1.25 -2.55,2.775 0,1.525 1.15,2.775 2.55,2.775 1.425,0 2.55,-1.25 2.55,-2.775 0.025,-1.525 -1.125,-2.775 -2.55,-2.775 z m 9.125,0 c -1.425,0 -2.55,1.25 -2.55,2.775 0,1.525 1.15,2.775 2.55,2.775 1.425,0 2.55,-1.25 2.55,-2.775 0,-1.525 -1.125,-2.775 -2.55,-2.775 z"
-     id="path4"
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;stroke-width:0.25" />
+     style="fill:#ffffff;" />
   <path
-     class="st0"
      d="M 42.056548,0 H 8.5565476 c -2.825,0 -5.125,2.3 -5.125,5.15 v 33.8 c 0,2.85 2.3,5.15 5.125,5.15 H 36.906548 l -1.325,-4.625 3.2,2.975 3.025,2.8 5.375,4.75 V 5.15 c 0,-2.85 -2.3,-5.15 -5.125,-5.15 z m -9.65,32.65 c 0,0 -0.9,-1.075 -1.65,-2.025 3.275,-0.925 4.525,-2.975 4.525,-2.975 -1.025,0.675 -2,1.15 -2.875,1.475 -1.25,0.525 -2.45,0.875 -3.625,1.075 -2.4,0.45 -4.6,0.325 -6.475,-0.025 -1.425,-0.275 -2.65,-0.675 -3.675,-1.075 -0.575,-0.225 -1.2,-0.5 -1.825,-0.85 -0.075,-0.05 -0.15,-0.075 -0.225,-0.125 -0.05,-0.025 -0.075,-0.05 -0.1,-0.075 -0.45,-0.25 -0.7,-0.425 -0.7,-0.425 0,0 1.2,2 4.375,2.95 -0.75,0.95 -1.675,2.075 -1.675,2.075 -5.525,-0.175 -7.625,-3.8 -7.625,-3.8 0,-8.05 3.6,-14.575 3.6,-14.575 3.6,-2.7 7.025,-2.625 7.025,-2.625 l 0.25,0.3 c -4.5,1.3 -6.575,3.275 -6.575,3.275 0,0 0.55,-0.3 1.475,-0.725 2.675,-1.175 4.8,-1.5 5.675,-1.575 0.15,-0.025 0.275,-0.05 0.425,-0.05 1.525,-0.2 3.25,-0.25 5.05,-0.05 2.375,0.275 4.925,0.975 7.525,2.4 0,0 -1.975,-1.875 -6.225,-3.175 l 0.35,-0.4 c 0,0 3.425,-0.075 7.025,2.625 0,0 3.6,6.525 3.6,14.575 0,0 -2.125,3.625 -7.65,3.8 z"
-     id="path6"
-     inkscape:connector-curvature="0"
-     style="fill:#ffffff;stroke-width:0.25" />
+     style="fill:#ffffff;" />
 </svg>

--- a/other/discord.svg
+++ b/other/discord.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="Layer_1"
+   viewBox="0 0 50 50"
+   version="1.1"
+   sodipodi:docname="discord.svg"
+   width="50"
+   height="50"
+   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs11" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1276"
+     inkscape:window-height="716"
+     id="namedview9"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="6.4111015"
+     inkscape:cx="14.250061"
+     inkscape:cy="16.725008"
+     inkscape:window-x="2"
+     inkscape:window-y="2"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" />
+  <style
+     id="style2">.st0{fill:#FFFFFF;}</style>
+  <path
+     class="st0"
+     d="m 20.781548,20.975 c -1.425,0 -2.55,1.25 -2.55,2.775 0,1.525 1.15,2.775 2.55,2.775 1.425,0 2.55,-1.25 2.55,-2.775 0.025,-1.525 -1.125,-2.775 -2.55,-2.775 z m 9.125,0 c -1.425,0 -2.55,1.25 -2.55,2.775 0,1.525 1.15,2.775 2.55,2.775 1.425,0 2.55,-1.25 2.55,-2.775 0,-1.525 -1.125,-2.775 -2.55,-2.775 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke-width:0.25" />
+  <path
+     class="st0"
+     d="M 42.056548,0 H 8.5565476 c -2.825,0 -5.125,2.3 -5.125,5.15 v 33.8 c 0,2.85 2.3,5.15 5.125,5.15 H 36.906548 l -1.325,-4.625 3.2,2.975 3.025,2.8 5.375,4.75 V 5.15 c 0,-2.85 -2.3,-5.15 -5.125,-5.15 z m -9.65,32.65 c 0,0 -0.9,-1.075 -1.65,-2.025 3.275,-0.925 4.525,-2.975 4.525,-2.975 -1.025,0.675 -2,1.15 -2.875,1.475 -1.25,0.525 -2.45,0.875 -3.625,1.075 -2.4,0.45 -4.6,0.325 -6.475,-0.025 -1.425,-0.275 -2.65,-0.675 -3.675,-1.075 -0.575,-0.225 -1.2,-0.5 -1.825,-0.85 -0.075,-0.05 -0.15,-0.075 -0.225,-0.125 -0.05,-0.025 -0.075,-0.05 -0.1,-0.075 -0.45,-0.25 -0.7,-0.425 -0.7,-0.425 0,0 1.2,2 4.375,2.95 -0.75,0.95 -1.675,2.075 -1.675,2.075 -5.525,-0.175 -7.625,-3.8 -7.625,-3.8 0,-8.05 3.6,-14.575 3.6,-14.575 3.6,-2.7 7.025,-2.625 7.025,-2.625 l 0.25,0.3 c -4.5,1.3 -6.575,3.275 -6.575,3.275 0,0 0.55,-0.3 1.475,-0.725 2.675,-1.175 4.8,-1.5 5.675,-1.575 0.15,-0.025 0.275,-0.05 0.425,-0.05 1.525,-0.2 3.25,-0.25 5.05,-0.05 2.375,0.275 4.925,0.975 7.525,2.4 0,0 -1.975,-1.875 -6.225,-3.175 l 0.35,-0.4 c 0,0 3.425,-0.075 7.025,2.625 0,0 3.6,6.525 3.6,14.575 0,0 -2.125,3.625 -7.65,3.8 z"
+     id="path6"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke-width:0.25" />
+</svg>


### PR DESCRIPTION
Fixes discord app logo.
Uses original logo instead of circled one