### PR TITLE
Add 10 new icons and fix Lexica's activity name

### DIFF
--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -123,6 +123,9 @@
     <!-- Ameixa Monochrome -->
     <item component="ComponentInfo{org.xphnx.ameixamonochrome/org.xphnx.ameixamonochrome.activities.MainActivity}" drawable="themes" />
 
+    <!-- Among Us -->
+    <item component="ComponentInfo{com.innersloth.spacemafia/com.unity3d.player.UnityPlayerActivity}" drawable="amongus"/>
+
     <!-- Ampere -->
     <item component="ComponentInfo{com.gombosdev.ampere/com.gombosdev.ampere.MainActivity}" drawable="ampere" />
 
@@ -191,6 +194,9 @@
 
     <!-- Applications Info -->
     <item component="ComponentInfo{com.majeur.applicationsinfo/com.majeur.applicationsinfo.MainActivity}" drawable="applicationsinfo" />
+
+    <!-- App Manager -->
+    <item component="ComponentInfo{io.github.muntashirakon.AppManager/io.github.muntashirakon.AppManager.main.MainActivity}" drawable="appmanager"/>
 
     <!-- Apps2Org -->
     <item component="ComponentInfo{com.google.code.apps2org/com.google.code.apps2org.SplashScreenActivity}" drawable="apps2org" />
@@ -2345,6 +2351,9 @@
 
     <!-- Rejseplanen -->
     <item component="ComponentInfo{de.hafas.android.rejseplanen/de.hafas.main.HafasApp}" drawable="rejseplanen"/>
+
+    <!-- Remixed Dungeon -->
+    <item component="ComponentInfo{com.nyrds.pixeldungeon.ml/com.watabou.pixeldungeon.RemixedDungeon}" drawable="remixeddungeon"/>
 
     <!-- Remote Desktop -->
     <item component="ComponentInfo{com.microsoft.rdc.android/com.microsoft.rdc.ui.actvities.HomeActivity}" drawable="remotedesktop" />

--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -1508,6 +1508,7 @@
 
     <!-- Lexica -->
     <item component="ComponentInfo{com.serwylo.lexica/com.serwylo.lexica.Lexica}" drawable="lexica" />
+    <item component="ComponentInfo{com.serwylo.lexica/com.serwylo.lexica.MainMenuActivity}" drawable="lexica"/>
 
     <!-- Libreflix -->
     <item component="ComponentInfo{org.libreflix.app/org.libreflix.app.MainActivity}" drawable="libreflix" />

--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -1042,6 +1042,9 @@
     <!-- Fossil Hybrid -->
     <item component="ComponentInfo{com.fossil.wearables.fossil/com.portfolio.platform.uirenew.splash.SplashScreenActivity}" drawable="fossilhybrid"/>
 
+    <!-- Foxy Droid -->
+    <item component="ComponentInfo{nya.kitsunyan.foxydroid/nya.kitsunyan.foxydroid.MainActivity}" drawable="foxydroid"/>
+
     <!-- Freebox Compagnon -->
     <item component="ComponentInfo{fr.freebox.android.compagnon/fr.freebox.android.compagnon.MainFreeboxActivity}" drawable="freebox" />
 
@@ -1256,6 +1259,9 @@
 
     <!-- Hacker's Keyboard -->
     <item component="ComponentInfo{org.pocketworkstation.pckeyboard/org.pocketworkstation.pckeyboard.Main}" drawable="hackerskb" />
+
+    <!-- Handy News Reader -->
+    <item component="ComponentInfo{ru.yanus171.feedexfork/ru.yanus171.feedexfork.activity.HomeActivity}" drawable="handynewsreader"/>
 
     <!-- Hauk -->
     <item component="ComponentInfo{info.varden.hauk/info.varden.hauk.ui.MainActivity}" drawable="hauk" />
@@ -1983,6 +1989,9 @@
     <!-- Oeffi Stations -->
     <item component="ComponentInfo{de.schildbach.oeffi/de.schildbach.oeffi.stations.StationsActivity}" drawable="oeffistations" />
 
+    <!-- Office -->
+    <item component="ComponentInfo{com.microsoft.office.officehubrow/com.microsoft.office.officesuite.OfficeSuiteActivity}" drawable="office"/>
+
     <!-- Offline Calendar -->
     <item component="ComponentInfo{org.sufficientlysecure.localcalendar/org.sufficientlysecure.localcalendar.ui.MainActivity}" drawable="offlinecalendar" />
 
@@ -2477,8 +2486,8 @@
     <item component="ComponentInfo{com.jim.sharetocomputer/com.jim.sharetocomputer.MainActivity}" drawable="sharetocomputer" />
 
     <!-- Shattered Pixel Dungeon -->
-    <item component="ComponentInfo{com.shatteredpixel.shatteredpixeldungeon/com.shatteredpixel.shatteredpixeldungeon.android.AndroidLauncher}" drawable="pixeldungeon" />
-    <item component="ComponentInfo{com.shatteredpixel.shatteredpixeldungeon/com.shatteredpixel.shatteredpixeldungeon.ShatteredPixelDungeon}" drawable="pixeldungeon" />
+    <item component="ComponentInfo{com.shatteredpixel.shatteredpixeldungeon/com.shatteredpixel.shatteredpixeldungeon.android.AndroidLauncher}" drawable="shatteredpixeldungeon" />
+    <item component="ComponentInfo{com.shatteredpixel.shatteredpixeldungeon/com.shatteredpixel.shatteredpixeldungeon.ShatteredPixelDungeon}" drawable="shatteredpixeldungeon" />
 
     <!-- Shazam -->
     <item component="ComponentInfo{com.shazam.android/com.shazam.android.activities.SplashActivity}" drawable="shazam" />
@@ -3057,6 +3066,26 @@
     <!-- Simple Weather -->
     <item component="ComponentInfo{com.a5corp.weather/com.a5corp.weather.GlobalActivity}" drawable="simpleweather" />
 
+    <!-- Simple Thank You -->
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Pink}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Purple}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Deep_purple}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Indigo}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Blue}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Light_blue}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Cyan}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Teal}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Green}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Light_green}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Lime}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Yellow}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Amber}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Orange}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Deep_orange}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Brown}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Blue_grey}" drawable="simplethankyou" />
+    <item component="ComponentInfo{com.simplemobiletools.thankyou/com.simplemobiletools.thankyou.activities.SplashActivity.Grey_black}" drawable="simplethankyou" />
+
     <!-- Sim Toolkit -->
     <item component="ComponentInfo{com.android.stk/com.android.stk.StkMain}" drawable="sim" />
     <item component="ComponentInfo{com.android.stk/com.android.stk.StkLauncherActivity2}" drawable="sim" />
@@ -3133,6 +3162,9 @@
 
     <!-- Spotify -->
     <item component="ComponentInfo{com.spotify.music/com.spotify.music.MainActivity}" drawable="spotify" />
+
+    <!-- Sprouted Pixel Dungeon -->
+    <item component="ComponentInfo{com.github.dachhack.sprout/com.github.dachhack.sprout.ShatteredPixelDungeon}" drawable="sproutedpixeldungeon"/>
 
     <!-- stadtmobil -->
     <item component="ComponentInfo{de.cantamen.stadtmobil/de.cantamen.stadtmobil.MainActivity}" drawable="stadtmobil" />
@@ -3645,6 +3677,9 @@
 
     <!-- Yandex Weather -->
     <item component="ComponentInfo{ru.yandex.weatherplugin/ru.yandex.weatherplugin.ui.activity.SplashActivity}" drawable="yaweather" />
+
+    <!-- YAPD / Yet Another Pixel Dungeon -->
+    <item component="ComponentInfo{com.consideredhamster.yetanotherpixeldungeon/com.consideredhamster.yetanotherpixeldungeon.YetAnotherPixelDungeon}" drawable="yapd"/>
 
     <!-- Yatse -->
     <item component="ComponentInfo{org.leetzone.android.yatsewidgetfree/org.leetzone.android.yatsewidget.ui.StartActivity}" drawable="yatse" />

--- a/other/amongus.svg
+++ b/other/amongus.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48px"
+   height="48px"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="SVGRoot"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="amongus.svg">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.7712362"
+     inkscape:cx="24.779946"
+     inkscape:cy="25.671732"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1024"
+     inkscape:window-height="581"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     inkscape:pagecheckerboard="true" />
+  <defs
+     id="defs26" />
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Capa 1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Capa 2"
+     style="opacity:1">
+    <path
+       style="fill:#ffffff;stroke:none;stroke-width:0.18174262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.849511,13.847225 c 0.928164,0.97492 2.297917,1.104214 1.5346,6.846032 -0.686857,1.438949 -1.633468,3.02348 -4.49,4.507017 -4.75894,1.185491 -9.304899,0.692825 -14.0638384,-1.976948 -4.5072785,-3.461242 -0.7174328,-9.139463 4.2167824,-10.060036 4.616514,-0.48573 8.978776,-0.756744 12.802456,0.683935 z"
+       id="path73"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#ffffff;stroke:none;stroke-width:0.09087131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.912246,9.5953163 c 1.407317,-1.7253401 2.619859,-3.4461491 8.774761,-5.2818957 l 6.304197,0.1703836 c 3.910743,0.3084538 5.657076,2.708244 7.241308,7.2413078 0.71314,2.63618 0.820631,5.277951 1.703836,7.582074 l 0.08519,23.598144 H 6.652654 C 5.4345488,37.780131 6.0383254,32.427205 6.588756,27.080943 c 6.868591,2.755317 12.726502,1.668771 17.613416,-0.873217 2.960719,-2.833155 4.00205,-6.171308 3.492865,-10.563786 -1.394379,-2.114131 -1.339351,-3.478889 -5.452279,-5.537474 L 16.790484,9.5101242 Z"
+       id="path883"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="fill:#ffffff;stroke:none;stroke-width:0.09087131;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38.028412,42.861479 c 0.535557,-7.353798 0.587059,-14.828224 -0.120474,-22.409181 1.22639,0.09677 3.123593,0.154074 3.493902,0.301198 0.531606,0.326428 0.867206,0.701856 1.174676,1.084315 1.332064,7.523585 1.253579,16.002315 0.604538,21.053788 z"
+       id="path885"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+</svg>

--- a/other/appmanager.svg
+++ b/other/appmanager.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg12"
+   sodipodi:docname="appmanager.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata18">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs16" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1024"
+     inkscape:window-height="581"
+     id="namedview14"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="8.5208333"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg12" />
+  <path
+     d="M 7 5 C 5.892 5 5 5.892 5 7 L 5 41 C 5 42.108 5.892 43 7 43 L 41 43 C 42.108 43 43 42.108 43 41 L 43 7 C 43 5.892 42.108 5 41 5 L 7 5 z M 20.996094 9 L 26.996094 9 C 27.371095 9 27.678594 9.2783594 27.746094 9.6308594 L 28.308594 13.605469 C 29.223594 13.987969 30.07125 14.489531 30.84375 15.082031 L 34.578125 13.576172 C 34.915625 13.441171 35.306641 13.575938 35.494141 13.898438 L 38.494141 19.09375 C 38.681641 19.42375 38.5975 19.831641 38.3125 20.056641 L 35.142578 22.537109 C 35.202576 23.017109 35.246094 23.505 35.246094 24 C 35.246094 24.495 35.202578 24.982891 35.142578 25.462891 L 38.306641 27.943359 C 38.591641 28.175859 38.673828 28.58375 38.486328 28.90625 L 35.486328 34.101562 C 35.301283 34.418428 34.913137 34.55463 34.570312 34.423828 L 30.837891 32.917969 C 30.061994 33.520474 29.207438 34.016375 28.300781 34.394531 L 27.738281 38.369141 C 27.678281 38.721641 27.371094 39 26.996094 39 L 20.996094 39 C 20.621094 39 20.313906 38.721641 20.253906 38.369141 L 19.691406 34.394531 C 18.776406 34.012031 17.92875 33.510469 17.15625 32.917969 L 13.421875 34.423828 C 13.084375 34.558828 12.693359 34.424062 12.505859 34.101562 L 9.5058594 28.90625 C 9.3183594 28.57625 9.4025 28.168359 9.6875 27.943359 L 12.851562 25.462891 C 12.791565 24.982891 12.746094 24.495 12.746094 24 C 12.75068 23.510792 12.786215 23.021954 12.851562 22.537109 L 9.6875 20.056641 C 9.402501 19.824141 9.3183594 19.41625 9.5058594 19.09375 L 12.505859 13.898438 C 12.690904 13.581571 13.07905 13.445369 13.421875 13.576172 L 17.15625 15.082031 C 17.932147 14.479526 18.784749 13.983625 19.691406 13.605469 L 20.253906 9.6308594 C 20.313906 9.2783594 20.621094 9 20.996094 9 z M 24 19.5 A 4.5000002 4.5000002 0 0 0 19.5 24 A 4.5000002 4.5000002 0 0 0 24 28.5 A 4.5000002 4.5000002 0 0 0 28.5 24 A 4.5000002 4.5000002 0 0 0 24 19.5 z "
+     id="rect10"
+     style="fill:#ffffff" />
+  <path
+     style="fill:#ff00ff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="path1022"
+     cy="24"
+     r="4" />
+</svg>

--- a/other/foxydroid.svg
+++ b/other/foxydroid.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="foxydroid.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="25.985711"
+     inkscape:cy="23.012649"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer2"
+     showgrid="false"
+     units="px"
+     inkscape:pagecheckerboard="true"
+     inkscape:window-width="1012"
+     inkscape:window-height="569"
+     inkscape:window-x="4"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-284.3)"
+     style="display:inline;opacity:1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Capa 2"
+     style="display:inline;opacity:1">
+    <path
+       transform="translate(0,-284.3)"
+       style="opacity:1;fill:#ffffff;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 5.8298164,289.33271 3.8419996,1.30293 -0.868626,-4.2596 z"
+       id="path40"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       transform="translate(0,-284.3)"
+       style="opacity:1;fill:#ffffff;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 6.3309469,289.66679 1.65373,5.27858 2.0546351,-3.95893 z"
+       id="path42"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       transform="translate(0,-284.3)"
+       style="opacity:1;fill:#ffffff;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7.8173558,295.00011 -4.2905332,-2.15296 2.6466725,-3.09957 z"
+       id="path44"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       transform="translate(0,-284.3)"
+       style="opacity:1;fill:#ffffff;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 3.4135975,292.6769 2.6415342,-3.06928 -4.1888742,-0.9349 z"
+       id="path46"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/other/foxydroid.svg
+++ b/other/foxydroid.svg
@@ -54,7 +54,6 @@
      inkscape:label="Capa 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-284.3)"
      style="display:inline;opacity:1" />
   <g
      inkscape:groupmode="layer"
@@ -62,30 +61,26 @@
      inkscape:label="Capa 2"
      style="display:inline;opacity:1">
     <path
-       transform="translate(0,-284.3)"
        style="opacity:1;fill:#ffffff;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 5.8298164,289.33271 3.8419996,1.30293 -0.868626,-4.2596 z"
+       d="M 5.8298164,5.03271 9.671816,6.33564 8.80319,2.07604 Z"
        id="path40"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
     <path
-       transform="translate(0,-284.3)"
        style="opacity:1;fill:#ffffff;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 6.3309469,289.66679 1.65373,5.27858 2.0546351,-3.95893 z"
+       d="m 6.3309469,5.36679 1.65373,5.27858 2.0546351,-3.95893 z"
        id="path42"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
     <path
-       transform="translate(0,-284.3)"
        style="opacity:1;fill:#ffffff;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 7.8173558,295.00011 -4.2905332,-2.15296 2.6466725,-3.09957 z"
+       d="M 7.8173558,10.70011 3.5268226,8.54715 6.1734951,5.44758 Z"
        id="path44"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
     <path
-       transform="translate(0,-284.3)"
        style="opacity:1;fill:#ffffff;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 3.4135975,292.6769 2.6415342,-3.06928 -4.1888742,-0.9349 z"
+       d="M 3.4135975,8.3769 6.0551317,5.30762 1.8662575,4.37272 Z"
        id="path46"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />

--- a/other/handynewsreader.svg
+++ b/other/handynewsreader.svg
@@ -57,61 +57,52 @@
      inkscape:cy="18.98804"
      inkscape:window-x="4"
      inkscape:window-y="23"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="layer1" />
-  <g
-     transform="matrix(0.15952866,0,0,0.15952866,2858.3002,2418.1296)"
-     id="layer1"
-     inkscape:label="Layer 1"
-     style="fill:#ffffff;stroke:none">
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:9;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m -17715.898,-14926.473 c -5.001,4.512 -10.34,8.28 -16.05,10.969 l -1.323,5.265 c -1.206,4.825 -88.687,4.825 -89.925,0 l -1.31,-5.13 c -5.338,-2.533 -10.35,-6.028 -15.071,-10.162 a 105.87886,16.910036 0 0 0 -39.888,13.223 105.87886,16.910036 0 0 0 105.878,16.907 105.87886,16.910036 0 0 0 105.878,-16.907 105.87886,16.910036 0 0 0 -48.189,-14.165 z"
-       id="path4615-7"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       d="m -17683.732,-14990.626 c 26.428,-18.178 27.314,4.271 8.513,17.126 -3.025,2.068 -8.411,3.978 -16.143,4.548 3.933,-8.191 6.424,-17.544 7.63,-21.674 z m -194.464,-42.906 c -1.618,39.594 20.247,98.94 56.063,115.936 l 1.249,4.869 c 1.175,4.581 84.229,4.581 85.374,0 l 1.249,-4.998 c 13.142,-6.189 24.401,-18.1 33.324,-32.652 v 0 c 0,0 17.46,-1.18 26.696,-5.893 43.106,-21.997 41.744,-72.26 -5.15,-54.802 1.144,-7.873 1.617,-15.474 1.361,-22.46 0,8.029 -44.808,14.537 -100.083,14.537 -55.275,0 -100.084,-6.508 -100.083,-14.537 z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path864" />
-    <ellipse
-       ry="14.536803"
-       rx="100.08292"
-       cy="-15037.358"
-       cx="-17778.113"
-       id="path852"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       sodipodi:nodetypes="ccc"
-       inkscape:connector-curvature="0"
-       id="path906"
-       d="m -17768.052,-15141.459 c -99.665,62.72 60.988,44.238 -23.277,90.229 116.48,-47.574 -53.795,-30.326 23.277,-90.229 z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06475449;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <g
-       id="g1148">
-      <path
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:9;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m -17715.898,-14926.473 c -5.001,4.512 -10.34,8.28 -16.05,10.969 l -1.323,5.265 c -1.206,4.825 -88.687,4.825 -89.925,0 l -1.31,-5.13 c -5.338,-2.533 -10.35,-6.028 -15.071,-10.162 a 105.87886,16.910036 0 0 0 -39.888,13.223 105.87886,16.910036 0 0 0 105.878,16.907 105.87886,16.910036 0 0 0 105.878,-16.907 105.87886,16.910036 0 0 0 -48.189,-14.165 z"
-         id="path1136"
-         inkscape:connector-curvature="0" />
-      <path
-         inkscape:connector-curvature="0"
-         d="m -17683.732,-14990.626 c 26.428,-18.178 27.314,4.271 8.513,17.126 -3.025,2.068 -8.411,3.978 -16.143,4.548 3.933,-8.191 6.424,-17.544 7.63,-21.674 z m -194.464,-42.906 c -1.618,39.594 20.247,98.94 56.063,115.936 l 1.249,4.869 c 1.175,4.581 84.229,4.581 85.374,0 l 1.249,-4.998 c 13.142,-6.189 24.401,-18.1 33.324,-32.652 v 0 c 0,0 17.46,-1.18 26.696,-5.893 43.106,-21.997 41.744,-72.26 -5.15,-54.802 1.144,-7.873 1.617,-15.474 1.361,-22.46 0,8.029 -44.808,14.537 -100.083,14.537 -55.275,0 -100.084,-6.508 -100.083,-14.537 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path1138" />
-      <ellipse
-         ry="14.536803"
-         rx="100.08292"
-         cy="-15037.358"
-         cx="-17778.113"
-         id="ellipse1140"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         sodipodi:nodetypes="ccc"
-         inkscape:connector-curvature="0"
-         id="path1142"
-         d="m -17768.052,-15141.459 c -99.665,62.72 60.988,44.238 -23.277,90.229 116.48,-47.574 -53.795,-30.326 23.277,-90.229 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06475449;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    </g>
-  </g>
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1069" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path4615-7"
+     d="m 32.106731,36.929364 c -0.797802,0.719793 -1.649526,1.320897 -2.560435,1.74987 l -0.211056,0.839918 c -0.192392,0.769726 -14.148118,0.769726 -14.345615,0 L 14.780643,38.70077 c -0.851564,-0.404086 -1.651122,-0.961639 -2.404257,-1.62113 a 16.890713,2.6976354 0 0 0 -6.363279,2.109447 16.890713,2.6976354 0 0 0 16.890575,2.697151 16.890713,2.6976354 0 0 0 16.890576,-2.697151 16.890713,2.6976354 0 0 0 -7.687527,-2.259723 z"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.43575799;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path864"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.27622926;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 37.23813,26.695122 c 4.216024,-2.899912 4.357366,0.681347 1.358068,2.732087 -0.482574,0.329906 -1.341796,0.634605 -2.575271,0.725537 0.627426,-1.306699 1.024812,-2.798771 1.217203,-3.457624 z M 6.2155489,19.850385 C 5.9574315,26.166763 9.4455257,35.634151 15.159204,38.3455 l 0.199251,0.776745 c 0.187447,0.730801 13.43694,0.730801 13.6196,0 l 0.199252,-0.797324 c 2.096525,-0.987323 3.892658,-2.887469 5.316133,-5.20893 v 0 c 0,0 2.78537,-0.188244 4.258777,-0.940103 6.876642,-3.509152 6.659364,-11.527541 -0.821573,-8.742489 0.182501,-1.255969 0.257958,-2.468547 0.217119,-3.583014 0,1.280856 -7.148161,2.319068 -15.966107,2.319068 -8.817947,0 -15.9662666,-1.038212 -15.9661071,-2.319068 z"
+     inkscape:connector-curvature="0" />
+  <ellipse
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.27622926;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path852"
+     cx="22.18161"
+     cy="19.239965"
+     rx="15.966093"
+     ry="2.3190367" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.64844483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 23.786674,2.6329353 C 7.8872497,12.638573 33.516008,9.6901641 20.073325,17.027047 38.655223,9.4376303 11.491481,12.189181 23.786674,2.6329353 Z"
+     id="path906"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.43575799;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 32.106731,36.929364 c -0.797802,0.719793 -1.649526,1.320897 -2.560435,1.74987 l -0.211056,0.839918 c -0.192392,0.769726 -14.148118,0.769726 -14.345615,0 L 14.780643,38.70077 c -0.851564,-0.404086 -1.651122,-0.961639 -2.404257,-1.62113 a 16.890713,2.6976354 0 0 0 -6.363279,2.109447 16.890713,2.6976354 0 0 0 16.890575,2.697151 16.890713,2.6976354 0 0 0 16.890576,-2.697151 16.890713,2.6976354 0 0 0 -7.687527,-2.259723 z"
+     id="path1136"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 37.23813,26.695122 c 4.216024,-2.899912 4.357366,0.681347 1.358068,2.732087 -0.482574,0.329906 -1.341796,0.634605 -2.575271,0.725537 0.627426,-1.306699 1.024812,-2.798771 1.217203,-3.457624 z M 6.2155489,19.850385 C 5.9574315,26.166763 9.4455257,35.634151 15.159204,38.3455 l 0.199251,0.776745 c 0.187447,0.730801 13.43694,0.730801 13.6196,0 l 0.199252,-0.797324 c 2.096525,-0.987323 3.892658,-2.887469 5.316133,-5.20893 v 0 c 0,0 2.78537,-0.188244 4.258777,-0.940103 6.876642,-3.509152 6.659364,-11.527541 -0.821573,-8.742489 0.182501,-1.255969 0.257958,-2.468547 0.217119,-3.583014 0,1.280856 -7.148161,2.319068 -15.966107,2.319068 -8.817947,0 -15.9662666,-1.038212 -15.9661071,-2.319068 z"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.27622926;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path1138" />
+  <ellipse
+     ry="2.3190367"
+     rx="15.966093"
+     cy="19.239965"
+     cx="22.18161"
+     id="ellipse1140"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.27622926;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccc"
+     inkscape:connector-curvature="0"
+     id="path1142"
+     d="M 23.786674,2.6329353 C 7.8872497,12.638573 33.516008,9.6901641 20.073325,17.027047 38.655223,9.4376303 11.491481,12.189181 23.786674,2.6329353 Z"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.64844483;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/other/handynewsreader.svg
+++ b/other/handynewsreader.svg
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1069"
+   sodipodi:docname="handynewsreader.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata1075">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1073">
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient2439">
+      <stop
+         id="stop2437"
+         offset="0"
+         style="stop-color:#ec7d03;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1012"
+     inkscape:window-height="569"
+     id="namedview1071"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="41.273541"
+     inkscape:cy="18.98804"
+     inkscape:window-x="4"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <g
+     transform="matrix(0.15952866,0,0,0.15952866,2858.3002,2418.1296)"
+     id="layer1"
+     inkscape:label="Layer 1"
+     style="fill:#ffffff;stroke:none">
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:9;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -17715.898,-14926.473 c -5.001,4.512 -10.34,8.28 -16.05,10.969 l -1.323,5.265 c -1.206,4.825 -88.687,4.825 -89.925,0 l -1.31,-5.13 c -5.338,-2.533 -10.35,-6.028 -15.071,-10.162 a 105.87886,16.910036 0 0 0 -39.888,13.223 105.87886,16.910036 0 0 0 105.878,16.907 105.87886,16.910036 0 0 0 105.878,-16.907 105.87886,16.910036 0 0 0 -48.189,-14.165 z"
+       id="path4615-7"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m -17683.732,-14990.626 c 26.428,-18.178 27.314,4.271 8.513,17.126 -3.025,2.068 -8.411,3.978 -16.143,4.548 3.933,-8.191 6.424,-17.544 7.63,-21.674 z m -194.464,-42.906 c -1.618,39.594 20.247,98.94 56.063,115.936 l 1.249,4.869 c 1.175,4.581 84.229,4.581 85.374,0 l 1.249,-4.998 c 13.142,-6.189 24.401,-18.1 33.324,-32.652 v 0 c 0,0 17.46,-1.18 26.696,-5.893 43.106,-21.997 41.744,-72.26 -5.15,-54.802 1.144,-7.873 1.617,-15.474 1.361,-22.46 0,8.029 -44.808,14.537 -100.083,14.537 -55.275,0 -100.084,-6.508 -100.083,-14.537 z"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path864" />
+    <ellipse
+       ry="14.536803"
+       rx="100.08292"
+       cy="-15037.358"
+       cx="-17778.113"
+       id="path852"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccc"
+       inkscape:connector-curvature="0"
+       id="path906"
+       d="m -17768.052,-15141.459 c -99.665,62.72 60.988,44.238 -23.277,90.229 116.48,-47.574 -53.795,-30.326 23.277,-90.229 z"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06475449;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       id="g1148">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:9;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m -17715.898,-14926.473 c -5.001,4.512 -10.34,8.28 -16.05,10.969 l -1.323,5.265 c -1.206,4.825 -88.687,4.825 -89.925,0 l -1.31,-5.13 c -5.338,-2.533 -10.35,-6.028 -15.071,-10.162 a 105.87886,16.910036 0 0 0 -39.888,13.223 105.87886,16.910036 0 0 0 105.878,16.907 105.87886,16.910036 0 0 0 105.878,-16.907 105.87886,16.910036 0 0 0 -48.189,-14.165 z"
+         id="path1136"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m -17683.732,-14990.626 c 26.428,-18.178 27.314,4.271 8.513,17.126 -3.025,2.068 -8.411,3.978 -16.143,4.548 3.933,-8.191 6.424,-17.544 7.63,-21.674 z m -194.464,-42.906 c -1.618,39.594 20.247,98.94 56.063,115.936 l 1.249,4.869 c 1.175,4.581 84.229,4.581 85.374,0 l 1.249,-4.998 c 13.142,-6.189 24.401,-18.1 33.324,-32.652 v 0 c 0,0 17.46,-1.18 26.696,-5.893 43.106,-21.997 41.744,-72.26 -5.15,-54.802 1.144,-7.873 1.617,-15.474 1.361,-22.46 0,8.029 -44.808,14.537 -100.083,14.537 -55.275,0 -100.084,-6.508 -100.083,-14.537 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path1138" />
+      <ellipse
+         ry="14.536803"
+         rx="100.08292"
+         cy="-15037.358"
+         cx="-17778.113"
+         id="ellipse1140"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path1142"
+         d="m -17768.052,-15141.459 c -99.665,62.72 60.988,44.238 -23.277,90.229 116.48,-47.574 -53.795,-30.326 23.277,-90.229 z"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4.06475449;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/other/office.svg
+++ b/other/office.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1069"
+   sodipodi:docname="office.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata1075">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1073" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1012"
+     inkscape:window-height="569"
+     id="namedview1071"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="13.766322"
+     inkscape:cy="22.895284"
+     inkscape:window-x="4"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1069"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 27.080633,12.610169 -8.440678,3 c -1.14467,0.504349 -1.637425,1.305023 -1.728813,2.288136 V 29.38983 c 0.0191,0.716639 -0.474489,1.305107 -1.220339,1.830509 l -3.752004,1.6897 c -1.005278,0.170664 -1.620415,-0.383507 -1.637827,-1.181225 V 15.152542 c 0.676302,-1.92653 1.561254,-2.273975 2.338983,-2.79661 L 23.256038,6.4960494 c 2.066203,-0.4444273 3.582493,0.6106884 3.824595,2.7073404 z"
+     id="path1201"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccccc" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 26.084746,6.5338982 c 0.533291,0.5210767 1.229604,0.7725878 1.474576,2.4152543 V 37.271186 c -0.08603,1.447498 -0.769854,2.113568 -1.5,2.745763 l 9.432203,-2.669491 c 0.774234,-0.225004 1.851466,-1.717447 1.90678,-2.338983 V 12.177966 C 37.290337,10.213735 36.13272,9.7204822 35.211864,9.3559321 Z"
+     id="path2329"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:0.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 22.148023,39.64056 c 1.512979,0.728068 1.998626,0.907582 3.253889,0.431455 0.799574,-0.600199 1.652766,-1.643071 1.689866,-2.840412 l 0.01798,-4.188709 H 16.646972 c -1.399509,0.475725 -2.230341,1.967206 -0.66516,3.092094 z"
+     id="path2331"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccc" />
+</svg>

--- a/other/remixeddungeon.svg
+++ b/other/remixeddungeon.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg18"
+   sodipodi:docname="remixeddungeon.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata24">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs22" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1012"
+     inkscape:window-height="569"
+     id="namedview20"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="4.1354167"
+     inkscape:cx="20.902253"
+     inkscape:cy="22.199532"
+     inkscape:window-x="4"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid63" />
+  </sodipodi:namedview>
+  <path
+     d="M 6,26.037467 V 40.105263 C 6,41.154947 6.8450526,42 7.8947368,42 H 40.105263 C 41.154947,42 42,41.154947 42,40.105263 V 7.8947368 C 42,6.8450526 41.154947,6 40.105263,6 h -18 V 8.8421053 H 39.157895 V 39.157895 H 8.8421053"
+     id="path10"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke-width:0.94736844"
+     sodipodi:nodetypes="cssssssccccc" />
+  <path
+     d="M 9.7894737,25.894737 H 7.392051 l -0.029735,2.357052 h 12.808421 l 0.03979,-2.357052 z M 29.443579,24.462316 v 3.789473 h 11.19221 V 24.462316 Z M 22.105263,7.3623158 V 21.826737 h 3.789474 V 7.3613684 Z"
+     id="path12"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke-width:0.94736844"
+     sodipodi:nodetypes="ccccccccccccccccc" />
+  <path
+     d="m 26.920737,23.436316 v 5.841473 h -5.841474 l 0.07863,-3.383052 h -3.789474 l -0.07863,7.171579 H 30.710211 V 19.648737 l -8.604948,0.116321 v 3.725739 M 6,25.894737 H 9.7894737 V 39.451579 H 6 Z M 38.210526,8.5484211 H 42 V 39.451579 h -3.789474 z"
+     id="path14"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke-width:0.94736844"
+     sodipodi:nodetypes="cccccccccccccccccccc" />
+  <path
+     d="M 38.813053,6 V 9.7894737 H 22.105263 V 6 Z m 0.638526,32.210526 V 42 H 8.5484211 v -3.789474 z"
+     id="path16"
+     inkscape:connector-curvature="0"
+     style="fill:#ffffff;stroke-width:0.94736844"
+     sodipodi:nodetypes="cccccccccc" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="R"
+     style="display:inline">
+    <path
+       style="display:inline;fill:#ffffff;stroke:none;stroke-width:1.11111116px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 7.000001,4.111111 V 5.222222 H 5.88889 V 6.333333 H 4.777779 V 23 H 5.88889 v 1.111111 H 8.111112 V 23 h 1.111111 v -5.555556 h 1.111111 v -1.111111 h 3.333333 v 1.111111 h 1.111111 v 1.111111 h 1.111111 V 23 H 17 v 1.111111 h 2.222223 V 23 h 1.111111 V 16.333333 H 19.222223 V 15.222222 H 18.111112 V 13 h 1.111111 v -1.111111 h 1.111111 V 6.333333 H 19.222223 V 5.222222 H 18.111112 V 4.111111 Z m 3.333333,3.333334 h 5.555555 v 1.11111 H 17 v 2.222223 h -1.111111 v 1.111111 H 10.333334 V 10.777778 H 9.222223 V 8.555555 h 1.111111 z"
+       id="path65"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/other/shatteredpixeldungeon.svg
+++ b/other/shatteredpixeldungeon.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg918"
+   sodipodi:docname="shatteredpixeldungeon.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata924">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs922" />
+  <sodipodi:namedview
+     pagecolor="#000000"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1024"
+     inkscape:window-height="581"
+     id="namedview920"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="4.9166666"
+     inkscape:cx="25.265824"
+     inkscape:cy="20.600191"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg918">
+    <inkscape:grid
+       type="xygrid"
+       id="grid932" />
+  </sodipodi:namedview>
+  <path
+     d="M7 5c-1.108 0-2 .892-2 2v34c0 1.108.892 2 2 2h34c1.108 0 2-.892 2-2V7c0-1.108-.892-2-2-2H7zm1 3h32v32H8V8z"
+     fill="#fff"
+     id="path910" />
+  <path
+     d="M6.438 24.488v4h13.52v-4zM29.746 24.488v4H41.56v-4zM22 6.438v15.268h4V6.437z"
+     fill="#fff"
+     id="path912" />
+  <path
+     d="M16.917 19.405V33.57h14.166V19.407H18.022zm4 4h6.166v6.166h-6.166zM5 7.69h4V40.31H5zM39 7.69h4V40.31h-4z"
+     fill="#fff"
+     id="path914" />
+  <path
+     d="M39.636 5v4H7.013V5zM40.31 39v4H7.69v-4z"
+     fill="#fff"
+     id="path916" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect934"
+     width="2"
+     height="2"
+     x="9"
+     y="37" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect936"
+     width="4"
+     height="2"
+     x="11"
+     y="35" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect940"
+     width="2"
+     height="2"
+     x="13"
+     y="31" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect944"
+     width="2"
+     height="2"
+     x="19"
+     y="35" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect960"
+     width="2"
+     height="2"
+     x="37"
+     y="9" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect962"
+     width="2"
+     height="4"
+     x="35"
+     y="11" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect964"
+     width="4"
+     height="2"
+     x="31"
+     y="15" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect966"
+     width="2"
+     height="4"
+     x="29"
+     y="17" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect968"
+     width="2"
+     height="2"
+     x="27"
+     y="15" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect36"
+     width="4"
+     height="2"
+     x="15"
+     y="33" />
+</svg>

--- a/other/simplethankyou.svg
+++ b/other/simplethankyou.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48px"
+   height="48px"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="SVGRoot"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="simplethankyou.svg">
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.3333333"
+     inkscape:cx="14.628179"
+     inkscape:cy="23.109612"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1012"
+     inkscape:window-height="569"
+     inkscape:window-x="4"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     inkscape:pagecheckerboard="true" />
+  <defs
+     id="defs164" />
+  <metadata
+     id="metadata167">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:groupmode="layer"
+     inkscape:label="Capa 1">
+    <path
+       style="fill:#ffffff;stroke-width:0.22126964"
+       d="M 21.786794,41.177207 C 15.543793,37.41787 7.4090442,29.996654 4.8050574,25.685003 3.2652362,23.13539 2.6952939,19.877121 3.3157796,17.171036 4.0594354,13.927786 6.6176715,10.640927 9.4701347,9.2638409 10.948309,8.5502212 11.400236,8.4402924 13.185804,8.3600449 16.879215,8.194054 19.142781,9.2273188 22.327107,12.532844 l 1.880793,1.952373 1.15953,-1.418045 c 1.416468,-1.732274 3.236861,-3.1999971 5.142003,-4.145826 1.354166,-0.6722941 1.569349,-0.7117266 3.883693,-0.7117266 2.40354,0 2.483513,0.016472 4.208775,0.8674224 5.465144,2.6955412 7.906209,8.9743052 5.665062,14.5713122 -0.376716,0.940798 -1.033947,2.256128 -1.460511,2.922964 -1.944396,3.039577 -6.811193,7.721743 -12.247774,11.783121 -5.233856,3.909936 -6.363031,4.273306 -8.771884,2.822768 z"
+       id="path251"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssscssssscss" />
+  </g>
+</svg>

--- a/other/simplethankyou.svg
+++ b/other/simplethankyou.svg
@@ -23,19 +23,23 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="5.3333333"
-     inkscape:cx="14.628179"
-     inkscape:cy="23.109612"
+     inkscape:zoom="3.7712361"
+     inkscape:cx="12.60811"
+     inkscape:cy="30.99271"
      inkscape:document-units="px"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="layer2"
      showgrid="false"
-     inkscape:window-width="1012"
-     inkscape:window-height="569"
-     inkscape:window-x="4"
-     inkscape:window-y="23"
+     inkscape:window-width="1024"
+     inkscape:window-height="581"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
      inkscape:window-maximized="1"
      inkscape:grid-bbox="true"
-     inkscape:pagecheckerboard="true" />
+     inkscape:pagecheckerboard="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid42" />
+  </sodipodi:namedview>
   <defs
      id="defs164" />
   <metadata
@@ -53,12 +57,18 @@
   <g
      id="layer1"
      inkscape:groupmode="layer"
-     inkscape:label="Capa 1">
+     inkscape:label="Capa 1"
+     style="display:inline" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="heart"
+     style="opacity:1">
     <path
-       style="fill:#ffffff;stroke-width:0.22126964"
-       d="M 21.786794,41.177207 C 15.543793,37.41787 7.4090442,29.996654 4.8050574,25.685003 3.2652362,23.13539 2.6952939,19.877121 3.3157796,17.171036 4.0594354,13.927786 6.6176715,10.640927 9.4701347,9.2638409 10.948309,8.5502212 11.400236,8.4402924 13.185804,8.3600449 16.879215,8.194054 19.142781,9.2273188 22.327107,12.532844 l 1.880793,1.952373 1.15953,-1.418045 c 1.416468,-1.732274 3.236861,-3.1999971 5.142003,-4.145826 1.354166,-0.6722941 1.569349,-0.7117266 3.883693,-0.7117266 2.40354,0 2.483513,0.016472 4.208775,0.8674224 5.465144,2.6955412 7.906209,8.9743052 5.665062,14.5713122 -0.376716,0.940798 -1.033947,2.256128 -1.460511,2.922964 -1.944396,3.039577 -6.811193,7.721743 -12.247774,11.783121 -5.233856,3.909936 -6.363031,4.273306 -8.771884,2.822768 z"
-       id="path251"
+       style="opacity:1;fill:#ffffff;stroke:none;stroke-width:1.31746805px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 4.3317285,14.913825 C -2.0588022,27.289889 24.677869,43.075826 24.09375,41.252892 23.509631,43.075827 50.2463,27.289889 43.85577,14.913825 c -2.803988,-4.760537 -10.190498,-12.3461861 -19.76202,0 -5.74273,-8.3387432 -14.6611579,-8.9946643 -19.7620215,0 z"
+       id="path77"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="sssssscssssscss" />
+       sodipodi:nodetypes="ccccc" />
   </g>
 </svg>

--- a/other/sproutedpixeldungeon.svg
+++ b/other/sproutedpixeldungeon.svg
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg918"
+   sodipodi:docname="sproutedpixeldungeon.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata924">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs922" />
+  <sodipodi:namedview
+     pagecolor="#000000"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1024"
+     inkscape:window-height="581"
+     id="namedview920"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="4.9166666"
+     inkscape:cx="25.265824"
+     inkscape:cy="20.600191"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg918">
+    <inkscape:grid
+       type="xygrid"
+       id="grid932" />
+  </sodipodi:namedview>
+  <path
+     d="M7 5c-1.108 0-2 .892-2 2v34c0 1.108.892 2 2 2h34c1.108 0 2-.892 2-2V7c0-1.108-.892-2-2-2H7zm1 3h32v32H8V8z"
+     fill="#fff"
+     id="path910" />
+  <path
+     d="M6.438 24.488v4h13.52v-4zM29.746 24.488v4H41.56v-4zM22 6.438v15.268h4V6.437z"
+     fill="#fff"
+     id="path912" />
+  <path
+     d="M16.917 19.405V33.57h14.166V19.407H18.022zm4 4h6.166v6.166h-6.166zM5 7.69h4V40.31H5zM39 7.69h4V40.31h-4z"
+     fill="#fff"
+     id="path914" />
+  <path
+     d="M39.636 5v4H7.013V5zM40.31 39v4H7.69v-4z"
+     fill="#fff"
+     id="path916" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect119"
+     width="4"
+     height="2"
+     x="21"
+     y="36" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect121"
+     width="2"
+     height="3"
+     x="23"
+     y="33" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect123"
+     width="4"
+     height="2"
+     x="13"
+     y="20" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect125"
+     width="2"
+     height="2"
+     x="11"
+     y="18" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect127"
+     width="2"
+     height="4"
+     x="9"
+     y="14" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect129"
+     width="4"
+     height="2"
+     x="11"
+     y="14" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect131"
+     width="2"
+     height="2"
+     x="15"
+     y="16" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect133"
+     width="2"
+     height="2"
+     x="17"
+     y="18" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect135"
+     width="2"
+     height="2"
+     x="31"
+     y="20" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect137"
+     width="2"
+     height="2"
+     x="33"
+     y="18" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect139"
+     width="2"
+     height="4"
+     x="35"
+     y="14" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect141"
+     width="2"
+     height="2"
+     x="33"
+     y="12" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect143"
+     width="2"
+     height="2"
+     x="31"
+     y="14" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect145"
+     width="2.0829999"
+     height="3.4070001"
+     x="29"
+     y="16" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-opacity:1"
+     id="rect147"
+     width="2"
+     height="2"
+     x="27"
+     y="18" />
+</svg>

--- a/other/yapd.svg
+++ b/other/yapd.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg2398"
+   sodipodi:docname="yapd.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata2404">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2402" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1024"
+     inkscape:window-height="581"
+     id="namedview2400"
+     showgrid="false"
+     inkscape:pagecheckerboard="true"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="30.243582"
+     inkscape:cy="23.848472"
+     inkscape:window-x="0"
+     inkscape:window-y="19"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2398" />
+  <path
+     d="M 7 5 C 5.892 5 5 5.892 5 7 L 5 23.441406 L 8 23.441406 L 8 8 L 40 8 L 40 23.400391 L 43 23.400391 L 43 7 C 43 5.892 42.108 5 41 5 L 7 5 z M 40 27.367188 L 40 40 L 8 40 L 8 27.408203 L 5 27.408203 L 5 41 C 5 42.108 5.892 43 7 43 L 41 43 C 42.108 43 43 42.108 43 41 L 43 27.367188 L 40 27.367188 z "
+     id="path2390"
+     style="fill:#ffffff" />
+  <g
+     id="g2407"
+     transform="translate(0,-5.0651804)"
+     style="fill:#ffffff">
+    <path
+       id="path2392"
+       d="m 6.438,24.488 v 4 h 13.52 v -4 z m 23.308,0 v 4 H 41.56 v -4 z"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff"
+       sodipodi:nodetypes="cccccccccc" />
+  </g>
+  <path
+     d="M 5 7.6894531 L 5 23.441406 L 9 23.441406 L 9 7.6894531 L 5 7.6894531 z M 39 7.6894531 L 39 23.402344 L 43 23.402344 L 43 7.6894531 L 39 7.6894531 z M 16.917969 19.404297 L 16.917969 33.570312 L 31.082031 33.570312 L 31.082031 19.40625 L 18.021484 19.40625 L 16.917969 19.404297 z M 20.917969 23.404297 L 27.082031 23.404297 L 27.082031 29.570312 L 20.917969 29.570312 L 20.917969 23.404297 z M 39 27.367188 L 39 40.310547 L 43 40.310547 L 43 27.367188 L 39 27.367188 z M 5 27.40625 L 5 40.310547 L 9 40.310547 L 9 27.40625 L 5 27.40625 z "
+     id="path2394"
+     style="fill:#ffffff" />
+  <path
+     d="M39.636 5v4H7.013V5zM40.31 39v4H7.69v-4z"
+     fill="#fff"
+     id="path2396"
+     style="fill:#ffffff" />
+  <g
+     id="g2413"
+     style="display:inline;fill:#ffffff">
+    <path
+       d="m 22,6.438 v 15.268 h 4 V 6.437 Z"
+       id="path2411"
+       inkscape:connector-curvature="0"
+       style="fill:#ffffff"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+  <g
+     transform="translate(0,2.9348196)"
+     id="g2417"
+     style="display:inline;fill:#ffffff">
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       style="fill:#ffffff"
+       inkscape:connector-curvature="0"
+       d="m 6.438,24.488 v 4 h 13.52 v -4 z m 23.308,0 v 4 H 41.56 v -4 z"
+       id="path2415" />
+  </g>
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.20602125;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect6210"
+     width="2.0169492"
+     height="4.3695993"
+     x="9.0786343"
+     y="23.189724" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect6210-7"
+     width="2.0169492"
+     height="4.1179161"
+     x="12.905948"
+     y="23.361565" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.21140559;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 36.711865,25.451399 0.05085,12.124873 H 33.101696 V 27.433979 l -2.049411,0.03595 -0.01592,-1.988441 c 1.891606,-0.04117 3.783594,-0.03009 5.6755,-0.03009 z"
+     id="rect6231"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect6234"
+     width="2.4406779"
+     height="4.5366793"
+     x="36.661018"
+     y="23.338984" />
+</svg>

--- a/other/yapd.svg
+++ b/other/yapd.svg
@@ -35,63 +35,45 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1024"
-     inkscape:window-height="581"
+     inkscape:window-width="1012"
+     inkscape:window-height="569"
      id="namedview2400"
      showgrid="false"
      inkscape:pagecheckerboard="true"
-     inkscape:zoom="9.8333333"
-     inkscape:cx="30.243582"
-     inkscape:cy="23.848472"
-     inkscape:window-x="0"
-     inkscape:window-y="19"
-     inkscape:window-maximized="0"
+     inkscape:zoom="6.9532167"
+     inkscape:cx="4.859647"
+     inkscape:cy="31.728541"
+     inkscape:window-x="4"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
      inkscape:current-layer="svg2398" />
   <path
-     d="M 7 5 C 5.892 5 5 5.892 5 7 L 5 23.441406 L 8 23.441406 L 8 8 L 40 8 L 40 23.400391 L 43 23.400391 L 43 7 C 43 5.892 42.108 5 41 5 L 7 5 z M 40 27.367188 L 40 40 L 8 40 L 8 27.408203 L 5 27.408203 L 5 41 C 5 42.108 5.892 43 7 43 L 41 43 C 42.108 43 43 42.108 43 41 L 43 27.367188 L 40 27.367188 z "
+     inkscape:connector-curvature="0"
+     d="M 7,5 C 5.892,5 5,5.892 5,7 V 23.441406 H 8 V 8 h 32 v 15.400391 h 3 V 7 C 43,5.892 42.108,5 41,5 Z M 40,27.367188 V 40 H 8 V 27.408203 H 5 V 41 c 0,1.108 0.892,2 2,2 h 34 c 1.108,0 2,-0.892 2,-2 V 27.367188 Z"
      id="path2390"
      style="fill:#ffffff" />
-  <g
-     id="g2407"
-     transform="translate(0,-5.0651804)"
-     style="fill:#ffffff">
-    <path
-       id="path2392"
-       d="m 6.438,24.488 v 4 h 13.52 v -4 z m 23.308,0 v 4 H 41.56 v -4 z"
-       inkscape:connector-curvature="0"
-       style="fill:#ffffff"
-       sodipodi:nodetypes="cccccccccc" />
-  </g>
   <path
-     d="M 5 7.6894531 L 5 23.441406 L 9 23.441406 L 9 7.6894531 L 5 7.6894531 z M 39 7.6894531 L 39 23.402344 L 43 23.402344 L 43 7.6894531 L 39 7.6894531 z M 16.917969 19.404297 L 16.917969 33.570312 L 31.082031 33.570312 L 31.082031 19.40625 L 18.021484 19.40625 L 16.917969 19.404297 z M 20.917969 23.404297 L 27.082031 23.404297 L 27.082031 29.570312 L 20.917969 29.570312 L 20.917969 23.404297 z M 39 27.367188 L 39 40.310547 L 43 40.310547 L 43 27.367188 L 39 27.367188 z M 5 27.40625 L 5 40.310547 L 9 40.310547 L 9 27.40625 L 5 27.40625 z "
+     inkscape:connector-curvature="0"
+     d="M 5,7.6894531 V 23.441406 H 9 V 7.6894531 Z m 34,0 V 23.402344 h 4 V 7.6894531 Z M 16.917969,19.404297 V 33.570312 H 31.082031 V 19.40625 H 18.021484 Z m 4,4 h 6.164062 v 6.166015 H 20.917969 Z M 39,27.367188 v 12.943359 h 4 V 27.367188 Z M 5,27.40625 V 40.310547 H 9 V 27.40625 Z"
      id="path2394"
      style="fill:#ffffff" />
   <path
-     d="M39.636 5v4H7.013V5zM40.31 39v4H7.69v-4z"
-     fill="#fff"
+     inkscape:connector-curvature="0"
+     d="M 39.636,5 V 9 H 7.013 V 5 Z m 0.674,34 v 4 H 7.69 v -4 z"
      id="path2396"
      style="fill:#ffffff" />
-  <g
-     id="g2413"
-     style="display:inline;fill:#ffffff">
-    <path
-       d="m 22,6.438 v 15.268 h 4 V 6.437 Z"
-       id="path2411"
-       inkscape:connector-curvature="0"
-       style="fill:#ffffff"
-       sodipodi:nodetypes="ccccc" />
-  </g>
-  <g
-     transform="translate(0,2.9348196)"
-     id="g2417"
-     style="display:inline;fill:#ffffff">
-    <path
-       sodipodi:nodetypes="cccccccccc"
-       style="fill:#ffffff"
-       inkscape:connector-curvature="0"
-       d="m 6.438,24.488 v 4 h 13.52 v -4 z m 23.308,0 v 4 H 41.56 v -4 z"
-       id="path2415" />
-  </g>
+  <path
+     sodipodi:nodetypes="ccccc"
+     style="fill:#ffffff"
+     inkscape:connector-curvature="0"
+     id="path2411"
+     d="m 22,6.438 v 15.268 h 4 V 6.437 Z" />
+  <path
+     sodipodi:nodetypes="cccccccccc"
+     style="fill:#ffffff"
+     inkscape:connector-curvature="0"
+     d="m 6.438,19.42282 v 4 h 13.52 v -4 z m 23.308,0 v 4 H 41.56 v -4 z"
+     id="path2392" />
   <rect
      style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.20602125;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
      id="rect6210"
@@ -119,4 +101,10 @@
      height="4.5366793"
      x="36.661018"
      y="23.338984" />
+  <path
+     sodipodi:nodetypes="cccccccccc"
+     style="fill:#ffffff"
+     inkscape:connector-curvature="0"
+     d="m 6.438,27.42282 v 4 h 13.52 v -4 z m 23.308,0 v 4 H 41.56 v -4 z"
+     id="path273" />
 </svg>


### PR DESCRIPTION
Added icons for:

* Among Us
* App Manager
* Foxy Droid
* Handy News Reader
* Microsoft Office
* Remixed Dungeon
* Shattered Pixel Dungeon
* Simple Thank You
* Sprouted Pixel Dungeon
* YAPD (Yet Another Pixel Dungeon)

Added them to the appfilter.xml and fixed the activity name for Lexica by adding the new name.