### PR TITLE
Update Turtl usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are over **1000 icons!**, as well as a few **4K wallpapers** included. Sub
 This app doesn't have an icon request feature, so you'll have to do the following steps.
 
 1. **Install [Turtl](https://f-droid.org/packages/org.xphnx.iconsubmit)** which can extract the icons and class names of your apps.
-2. **Grant the storage access permission to Turtl** in your system settings, this will allow it to save the zip file. (Only required in Android 6 "Marshmallow" or newer, older versions grant this permission on installation).
+2. **Grant the storage access permission to Turtl** in your system settings, this will allow it to save the zip file (Only required in Android 6 "Marshmallow" or newer, older versions grant this permission on installation).
 3. **Open Turtl** and follow the process to save the new zip file to your phone.
 4. **[Make an issue](https://github.com/dkanada/frost/issues/new)** titled "Icon Request" and attach the zip file.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ There are over **1000 icons!**, as well as a few **4K wallpapers** included. Sub
 This app doesn't have an icon request feature, so you'll have to do the following steps.
 
 1. **Install [Turtl](https://f-droid.org/packages/org.xphnx.iconsubmit)** which can extract the icons and class names of your apps.
-2. **Open Turtl** and follow the process to save the new zip file to your phone.
-3. **[Make an issue](https://github.com/dkanada/frost/issues/new)** titled "Icon Request" and attach the zip file.
+2. **Grant the storage access permission to Turtl** in your system settings, this will allow it to save the zip file.
+3. **Open Turtl** and follow the process to save the new zip file to your phone.
+4. **[Make an issue](https://github.com/dkanada/frost/issues/new)** titled "Icon Request" and attach the zip file.
 
 If Turtl is not working on your device, you can also use [Applications Info](https://f-droid.org/packages/com.majeur.applicationsinfo) or any equivalent app to collect the **package name** of the app ($PACKAGE_NAME) and the **main activity name** of the app ($ACTIVITY_NAME) launchable in Applications Info with no errors. Work is being done to simplify this process.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are over **1000 icons!**, as well as a few **4K wallpapers** included. Sub
 This app doesn't have an icon request feature, so you'll have to do the following steps.
 
 1. **Install [Turtl](https://f-droid.org/packages/org.xphnx.iconsubmit)** which can extract the icons and class names of your apps.
-2. **Grant the storage access permission to Turtl** in your system settings, this will allow it to save the zip file.
+2. **Grant the storage access permission to Turtl** in your system settings, this will allow it to save the zip file. (Only required in Android 6 "Marshmallow" or newer, older versions grant this permission on installation).
 3. **Open Turtl** and follow the process to save the new zip file to your phone.
 4. **[Make an issue](https://github.com/dkanada/frost/issues/new)** titled "Icon Request" and attach the zip file.
 


### PR DESCRIPTION
Turtl fails to create a zip file if it doesn't have storage permission, but it doesn't seem to [request it when needed](https://gitlab.com/xphnx/icon-request-tool/-/issues/10).

This PR changes the Turtl usage instructions in the README file, adding a step telling the user to enable the storage access permission in the system settings before generating the zip file.