### PR TITLE
appfilter: Add Magisk v22.0 activity

### DIFF
--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -1732,6 +1732,7 @@
 
     <!-- Magisk Manager -->
     <item component="ComponentInfo{com.topjohnwu.magisk/com.topjohnwu.magisk.SplashActivity}" drawable="magisk" />
+    <item component="ComponentInfo{com.topjohnwu.magisk/com.topjohnwu.magisk.core.SplashActivity}" drawable="magisk" />
     <item component="ComponentInfo{com.topjohnwu.magisk/a.c}" drawable="magisk" />
 
     <!-- Ma Livebox -->


### PR DESCRIPTION
As the title says. On v22 Magisk Manager was renamed to Magisk and is now part of Magisk's core