### PR TITLE
Three new icons and fixes

### DIFF
--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -141,6 +141,9 @@
     <!-- andOTP -->
     <item component="ComponentInfo{org.shadowice.flocke.andotp/org.shadowice.flocke.andotp.Activities.MainActivity}" drawable="andotp" />
 
+    <!-- Android Customization -->
+    <item component="ComponentInfo{com.android.customization/com.android.customization.picker.CustomizationPickerActivity}" drawable="androidcustomization" />
+
     <!-- Android Keyboard -->
     <item component="ComponentInfo{com.android.inputmethod.latin/com.android.inputmethod.latin.setup.SetupActivity}" drawable="aospkeyboard" />
 

--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -3916,6 +3916,7 @@
 
     <!-- Wallabag -->
     <item component="ComponentInfo{fr.gaulupeau.apps.InThePoche/fr.gaulupeau.apps.Poche.ui.MainActivity}" drawable="wallabagger" />
+    <item component="ComponentInfo{fr.gaulupeau.apps.InThePoche/fr.gaulupeau.apps.Poche.ui.SplashActivity}" drawable="wallabagger" />
 
     <!-- Wallpapers -->
     <item component="ComponentInfo{com.google.android.apps.wallpaper/com.google.android.apps.wallpaper.picker.CategoryPickerActivity}" drawable="wallpapers" />

--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -1265,8 +1265,10 @@
 
     <!-- Google Camera -->
     <item component="ComponentInfo{com.google.android.GoogleCamera/com.android.camera.CameraLauncher}" drawable="gcamera" />
+    <item component="ComponentInfo{com.google.android.GoogleCameraEng/com.android.camera.CameraLauncher}" drawable="gcamera" />
     <item component="ComponentInfo{com.google.android.CameraRedmi5Plus/com.android.camera.CameraLauncher}" drawable="gcamera" />
     <item component="ComponentInfo{com.google.android.GoogleCamera.Urnyx/com.android.camera.CameraLauncher}" drawable="camera" />
+    <item component="ComponentInfo{org.codeaurora.snapcam/com.android.camera.CameraLauncher}" drawable="gcamera" />
 
     <!-- Google Chrome -->
     <item component="ComponentInfo{com.android.chrome/com.google.android.apps.chrome.Main}" drawable="chrome" />

--- a/app/src/main/res/xml/appfilter.xml
+++ b/app/src/main/res/xml/appfilter.xml
@@ -1424,6 +1424,9 @@
     <!-- Hulu -->
     <item component="ComponentInfo{com.hulu.plus/com.hulu.features.splash.SplashActivity}" drawable="hulu" />
 
+    <!-- Humpback -->
+    <item component="ComponentInfo{com.humpback/com.humpback.MainActivity}" drawable="humpback" />
+
     <!-- Hyperdia -->
     <item component="ComponentInfo{com.hyperdia.android.activity/com.hyperdia.android.activity.P10000}" drawable="bus_circle" />
 

--- a/other/androidcustomization.svg
+++ b/other/androidcustomization.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="androidcustomization.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2540"
+     inkscape:window-height="1394"
+     id="namedview6"
+     showgrid="false"
+     inkscape:pagecheckerboard="false"
+     inkscape:zoom="13.083333"
+     inkscape:cx="41.114263"
+     inkscape:cy="23.262969"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     inkscape:document-rotation="0" />
+  <path
+     id="circle2"
+     style="fill:#ffffff;fill-opacity:1"
+     d="M 24 2 C 11.849736 2 2 11.849736 2 24 C 2 36.150264 11.942171 45.793208 24.087891 45.460938 C 25.903348 45.411271 28.45171 43.792821 28.984375 41.107422 C 29.67733 37.613925 26.837593 36.282472 27.316406 35.158203 C 27.682006 34.299763 27.837568 34.581873 32.916016 34.658203 C 37.046765 34.720286 44.106677 31.172882 45.183594 23.896484 C 46.962472 11.877145 36.150264 2 24 2 z M 17.964844 10.814453 A 3.2092109 3.2092109 0 0 1 18.035156 10.814453 A 3.2092109 3.2092109 0 0 1 21.244141 14.023438 A 3.2092109 3.2092109 0 0 1 18.035156 17.232422 A 3.2092109 3.2092109 0 0 1 14.826172 14.023438 A 3.2092109 3.2092109 0 0 1 17.964844 10.814453 z M 28.830078 10.830078 A 3.2092109 3.2092109 0 0 1 28.900391 10.830078 A 3.2092109 3.2092109 0 0 1 32.109375 14.039062 A 3.2092109 3.2092109 0 0 1 28.900391 17.248047 A 3.2092109 3.2092109 0 0 1 25.691406 14.039062 A 3.2092109 3.2092109 0 0 1 28.830078 10.830078 z M 35.4375 19.390625 A 3.2092109 3.2092109 0 0 1 38.646484 22.599609 A 3.2092109 3.2092109 0 0 1 35.4375 25.810547 A 3.2092109 3.2092109 0 0 1 32.228516 22.599609 A 3.2092109 3.2092109 0 0 1 35.4375 19.390625 z M 11.484375 19.527344 A 3.2092109 3.2092109 0 0 1 11.554688 19.527344 A 3.2092109 3.2092109 0 0 1 14.763672 22.736328 A 3.2092109 3.2092109 0 0 1 11.554688 25.945312 A 3.2092109 3.2092109 0 0 1 8.3457031 22.736328 A 3.2092109 3.2092109 0 0 1 11.484375 19.527344 z " />
+</svg>

--- a/other/humpback.svg
+++ b/other/humpback.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg901"
+   sodipodi:docname="humpback.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
+  <metadata
+     id="metadata907">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs905">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath930">
+      <path
+         style="display:inline;opacity:1;fill:#c1d6dc;fill-opacity:1;stroke:none;stroke-width:1.989;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 1366.9435,124.46709 c -56.9587,-15.52528 -85.5117,31.77293 -85.5117,31.77293 0,0 -40.6796,-11.72549 -56.7674,29.5714 22.3314,-24.1552 49.3293,-13.88936 49.3293,-13.88936 -10.126,15.23126 -6.0633,95.50515 66.9174,101.09984 -87.061,-36.31974 -57.0423,-148.67068 26.0324,-148.55481 z"
+         id="path932"
+         sodipodi:nodetypes="cccccc"
+         inkscape:export-xdpi="600"
+         inkscape:export-ydpi="600" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath930-3">
+      <path
+         style="display:inline;opacity:1;fill:#c1d6dc;fill-opacity:1;stroke:none;stroke-width:1.989;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 1366.9435,124.46709 c -56.9587,-15.52528 -85.5117,31.77293 -85.5117,31.77293 0,0 -40.6796,-11.72549 -56.7674,29.5714 22.3314,-24.1552 49.3293,-13.88936 49.3293,-13.88936 -10.126,15.23126 -6.0633,95.50515 66.9174,101.09984 -87.061,-36.31974 -57.0423,-148.67068 26.0324,-148.55481 z"
+         id="path932-6"
+         sodipodi:nodetypes="cccccc"
+         inkscape:export-xdpi="600"
+         inkscape:export-ydpi="600" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2540"
+     inkscape:window-height="1373"
+     id="namedview903"
+     showgrid="false"
+     inkscape:pagecheckerboard="false"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="false"
+     inkscape:zoom="16.130873"
+     inkscape:cx="7.1663735"
+     inkscape:cy="14.675276"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg901"
+     inkscape:object-nodes="false" />
+  <path
+     id="circle1058"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.0682858;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 28.740539,8.4218752 C 21.656076,8.2030308 18.105774,14.083985 18.105774,14.083985 c 0,0 -6.606076,-1.903947 -9.21875,4.802734 3.626643,-3.922843 8.011719,-2.255857 8.011719,-2.25586 -0.215642,0.324363 -0.389504,0.838145 -0.50586,1.47461 0.9891,-0.888126 2.291716,-1.538281 3.939453,-1.798828 1.855375,-4.169797 5.991977,-7.3907185 11.660157,-7.3828127 -1.156274,-0.315166 -2.239887,-0.4706896 -3.251954,-0.5019531 z m 4.146485,0.703125 C 24.094571,9.292671 21.48468,16.779297 21.48468,16.779297 c -7.417143,0.317278 -8.965223,7.862367 -6.283203,11.773438 -0.752158,-7.373865 5.480469,-8.667969 5.480469,-8.667969 0,0 -1.010762,5.049204 2.648437,9.414062 0.790092,-0.505377 1.573804,-1.043928 2.357422,-1.59375 -0.997716,-3.003859 -0.240276,-6.686515 3.236328,-8.898437 0,0 6.165847,-2.715382 3.962891,-9.6816408 z M 25.687805,27.705078 c 0.665814,2.004589 2.105822,3.709964 4.068359,4.462891 1.17797,0.451928 2.3477,0.839484 3.703125,2.558594 0.03799,0.0482 0.09659,0.04631 0.15625,0.03125 0,0 3.945543,-1.167391 5.558594,2.990234 -3.22876,-2.779279 -8.400504,-0.706913 -8.091797,4.064453 -2.858805,-3.647128 0.953125,-6.328125 0.953125,-6.328125 0.03371,-0.03693 0.06917,-0.110094 0.03516,-0.146484 -1.763552,-1.887 -3.53052,-2.19312 -4.058593,-2.453125 -2.090664,-1.029371 -3.585912,-2.278903 -4.681641,-3.585938 -0.20984,0.134223 -0.419426,0.271601 -0.630859,0.398438 1.294242,1.322268 2.964313,2.476574 5.066406,3.353515 -2.859952,-0.219243 -5.055459,-1.151203 -6.734375,-2.46289 -1.221419,0.55723 -2.489642,0.914349 -3.849609,0.908203 C 11.538344,31.470584 2.000309,24 2.000309,24 c 0,12.150264 9.849735,22 22,22 12.150264,0 22,-9.849736 22,-22 0,0 -9.349673,-0.80553 -13.835938,0.265625 -2.335623,0.557661 -4.415661,1.993431 -6.476562,3.439453 z m -4.65625,2.882813 c 0.564933,-0.257731 1.119518,-0.561616 1.667969,-0.890625 -2.445533,-2.498489 -3.521876,-5.607938 -3.44336,-8.658203 -0.817947,0.397704 -1.823849,1.038703 -2.652343,2.138672 0.574965,2.628973 1.917141,5.448704 4.427734,7.410156 z" />
+</svg>


### PR DESCRIPTION
Icons added:

* Android Customization
* Modded Google Camera (to the appfilter, same icon as the original GCam)
* Humpback https://github.com/humpback-app/ and https://t.me/HumpbackApp

Fixed icons:
* Wallabagger

About Android Customization: I don't know whether it's the correct name. AOSiP uses this package name for the style editor, with the name `Styles & Wallpapers`. I'm not sure if other ROMs use it, but I did found something similar in Google's source: [ThemePicker](https://android.googlesource.com/platform/packages/apps/ThemePicker/+/refs/heads/master/AndroidManifest.xml)